### PR TITLE
Use CSS grids for filter component

### DIFF
--- a/library/src/frontend/src/components/TestClassFilter.vue
+++ b/library/src/frontend/src/components/TestClassFilter.vue
@@ -1,79 +1,79 @@
 <template>
     <div class="filter">
         <div class="grid-wrapper">
-                <div class="right-addon input-group">
-                    <input type="number" class="form-control" v-model="minSpringShare" @change="updateFunc"
-                        placeholder="Min. Spring share"
-                        data-toggle="tooltip" title="The minimum portion of time spent on Spring initialization">
-                    <div class="input-group-append"><span class="input-group-text">%</span></div>
-                </div>
-                <div class="right-addon input-group">
-                    <input type="number" class="form-control" v-model="maxSpringShare" @change="updateFunc"
-                        placeholder="Max. Spring share"
-                        data-toggle="tooltip" title="The maximum portion of time spent on Spring initialization">
-                    <div class="input-group-append"><span class="input-group-text">%</span></div>
-                </div>
-                <div class="right-addon input-group">
-                    <input type="number" class="form-control" v-model="minTime" @change="updateFunc"
-                           placeholder="Min. test time"
-                           data-toggle="tooltip" title="The minimum total duration of a test class">
-                    <div class="input-group-append"><span class="input-group-text">ms</span></div>
-                </div>
-                <div class="right-addon input-group">
-                    <input type="number" class="form-control" v-model="maxTime" @change="updateFunc"
-                           placeholder="Max. test time"
-                           data-toggle="tooltip" title="The maximum total duration of a test class">
-                    <div class="input-group-append"><span class="input-group-text">ms</span></div>
-                </div>
-                <div class="button-group input-group" data-toggle="tooltip"
-                     title="Filter tests that create their own Spring context and those that don't">
-                    <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
-                            style="white-space: nowrap;">
-                        Context creation<span class="caret" ></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li class="dropdown-checkbox">
-                            <input type="checkbox" id="include_spring_tests" checked
-                                   @change="updateFunc" v-model="includeSpring"/>
-                            <label for="include_spring_tests"
-                                   >Include Spring tests</label>
-                        </li>
-                        <li class="dropdown-checkbox">
-                            <input type="checkbox" id="include_non_spring_tests" checked
-                                   @change="updateFunc" v-model="includeNonSpring"/>
-                            <label for="include_non_spring_tests"
-                                   >Include non Spring tests</label>
-                        </li>
-                    </ul>
-                </div>
-                <div class="button-group input-group" data-toggle="tooltip"
-                     title="Filter tests based on their success">
-                    <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
-                            style="white-space: nowrap;">
-                        Test success<span class="caret" ></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li class="dropdown-checkbox">
-                            <input type="checkbox" id="include_succeeded_tests" checked
-                                   @change="updateFunc" v-model="includeSuccess"/>
-                            <label for="include_succeeded_tests"
-                                   >Include succeeded tests</label>
-                        </li>
-                        <li class="dropdown-checkbox">
-                            <input type="checkbox" id="include_partial_tests" checked
-                                   @change="updateFunc" v-model="includePartial"/>
-                            <label for="include_partial_tests"
-                                   >Include partial succeeded tests</label>
-                        </li>
-                        <li class="dropdown-checkbox">
-                            <input type="checkbox" id="include_failed_tests" checked
-                                   @change="updateFunc" v-model="includeFailure"/>
-                            <label for="include_failed_tests"
-                                   >Include failed tests</label>
-                        </li>
-                    </ul>
-                </div>
-                <button type="button" class="btn btn-light input-group" v-on:click="clearClicked()" style="background-color: #FFFFFF;">Clear</button>
+            <div class="right-addon input-group">
+                <input type="number" class="form-control" v-model="minSpringShare" @change="updateFunc"
+                    placeholder="Min. Spring share"
+                    data-toggle="tooltip" title="The minimum portion of time spent on Spring initialization">
+                <div class="input-group-append"><span class="input-group-text">%</span></div>
+            </div>
+            <div class="right-addon input-group">
+                <input type="number" class="form-control" v-model="maxSpringShare" @change="updateFunc"
+                    placeholder="Max. Spring share"
+                    data-toggle="tooltip" title="The maximum portion of time spent on Spring initialization">
+                <div class="input-group-append"><span class="input-group-text">%</span></div>
+            </div>
+            <div class="right-addon input-group">
+                <input type="number" class="form-control" v-model="minTime" @change="updateFunc"
+                       placeholder="Min. test time"
+                       data-toggle="tooltip" title="The minimum total duration of a test class">
+                <div class="input-group-append"><span class="input-group-text">ms</span></div>
+            </div>
+            <div class="right-addon input-group">
+                <input type="number" class="form-control" v-model="maxTime" @change="updateFunc"
+                       placeholder="Max. test time"
+                       data-toggle="tooltip" title="The maximum total duration of a test class">
+                <div class="input-group-append"><span class="input-group-text">ms</span></div>
+            </div>
+            <div class="button-group input-group" data-toggle="tooltip"
+                 title="Filter tests that create their own Spring context and those that don't">
+                <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
+                        style="white-space: nowrap;">
+                    Context creation<span class="caret" ></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li class="dropdown-checkbox">
+                        <input type="checkbox" id="include_spring_tests" checked
+                               @change="updateFunc" v-model="includeSpring"/>
+                        <label for="include_spring_tests"
+                               >Include Spring tests</label>
+                    </li>
+                    <li class="dropdown-checkbox">
+                        <input type="checkbox" id="include_non_spring_tests" checked
+                               @change="updateFunc" v-model="includeNonSpring"/>
+                        <label for="include_non_spring_tests"
+                               >Include non Spring tests</label>
+                    </li>
+                </ul>
+            </div>
+            <div class="button-group input-group" data-toggle="tooltip"
+                 title="Filter tests based on their success">
+                <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
+                        style="white-space: nowrap;">
+                    Test success<span class="caret" ></span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li class="dropdown-checkbox">
+                        <input type="checkbox" id="include_succeeded_tests" checked
+                               @change="updateFunc" v-model="includeSuccess"/>
+                        <label for="include_succeeded_tests"
+                               >Include succeeded tests</label>
+                    </li>
+                    <li class="dropdown-checkbox">
+                        <input type="checkbox" id="include_partial_tests" checked
+                               @change="updateFunc" v-model="includePartial"/>
+                        <label for="include_partial_tests"
+                               >Include partial succeeded tests</label>
+                    </li>
+                    <li class="dropdown-checkbox">
+                        <input type="checkbox" id="include_failed_tests" checked
+                               @change="updateFunc" v-model="includeFailure"/>
+                        <label for="include_failed_tests"
+                               >Include failed tests</label>
+                    </li>
+                </ul>
+            </div>
+            <button type="button" class="btn btn-light input-group" v-on:click="clearClicked()" style="background-color: #FFFFFF;">Clear</button>
         </div>
     </div>
 </template>

--- a/library/src/frontend/src/components/TestClassFilter.vue
+++ b/library/src/frontend/src/components/TestClassFilter.vue
@@ -73,7 +73,7 @@
                     </li>
                 </ul>
             </div>
-            <button type="button" class="btn btn-light input-group" v-on:click="clearClicked()" style="background-color: #FFFFFF;">Clear</button>
+            <button type="button" class="btn btn-light" v-on:click="clearClicked()" style="background-color: #FFFFFF;">Clear</button>
         </div>
     </div>
 </template>
@@ -138,7 +138,7 @@
     .grid-wrapper {
         display: grid;
         grid-gap: 10px;
-        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr) ) ;
+        grid-template-columns: repeat(auto-fill, minmax(207px, 1fr) ) ;
     }
 
     .input-group-text {

--- a/library/src/frontend/src/components/TestClassFilter.vue
+++ b/library/src/frontend/src/components/TestClassFilter.vue
@@ -17,13 +17,13 @@
                     <input type="number" class="form-control" v-model="minTime" @change="updateFunc"
                            placeholder="Min. test time"
                            data-toggle="tooltip" title="The minimum total duration of a test class">
-                    <div class="input-group-append"><span class="input-group-text">%</span></div>
+                    <div class="input-group-append"><span class="input-group-text">ms</span></div>
                 </div>
                 <div class="right-addon input-group">
                     <input type="number" class="form-control" v-model="maxTime" @change="updateFunc"
                            placeholder="Max. test time"
                            data-toggle="tooltip" title="The maximum total duration of a test class">
-                    <div class="input-group-append"><span class="input-group-text">%</span></div>
+                    <div class="input-group-append"><span class="input-group-text">ms</span></div>
                 </div>
                 <div class="button-group input-group" data-toggle="tooltip"
                      title="Filter tests that create their own Spring context and those that don't">

--- a/library/src/frontend/src/components/TestClassFilter.vue
+++ b/library/src/frontend/src/components/TestClassFilter.vue
@@ -1,95 +1,79 @@
 <template>
     <div class="filter">
-        <div class="form-inline" style="max-width: 1450px;">
-            <div class="col">
-                <div class="right-addon">
-                    <span>%</span>
+        <div class="grid-wrapper">
+                <div class="right-addon input-group">
                     <input type="number" class="form-control" v-model="minSpringShare" @change="updateFunc"
-                           placeholder="Min. Spring share"
-                           data-toggle="tooltip" title="The minimum portion of time spent on Spring initialization">
+                        placeholder="Min. Spring share"
+                        data-toggle="tooltip" title="The minimum portion of time spent on Spring initialization">
+                    <div class="input-group-append"><span class="input-group-text">%</span></div>
                 </div>
-            </div>
-            <div class="col">
-                <div class="right-addon">
-                    <span>%</span>
+                <div class="right-addon input-group">
                     <input type="number" class="form-control" v-model="maxSpringShare" @change="updateFunc"
-                           placeholder="Max. Spring share"
-                           data-toggle="tooltip" title="The maximum portion of time spent on Spring initialization">
+                        placeholder="Max. Spring share"
+                        data-toggle="tooltip" title="The maximum portion of time spent on Spring initialization">
+                    <div class="input-group-append"><span class="input-group-text">%</span></div>
                 </div>
-            </div>
-            <div class="col">
-                <div class="right-addon">
-                    <span>ms</span>
+                <div class="right-addon input-group">
                     <input type="number" class="form-control" v-model="minTime" @change="updateFunc"
                            placeholder="Min. test time"
                            data-toggle="tooltip" title="The minimum total duration of a test class">
+                    <div class="input-group-append"><span class="input-group-text">%</span></div>
                 </div>
-            </div>
-            <div class="col">
-                <div class="right-addon">
-                    <span>ms</span>
+                <div class="right-addon input-group">
                     <input type="number" class="form-control" v-model="maxTime" @change="updateFunc"
                            placeholder="Max. test time"
                            data-toggle="tooltip" title="The maximum total duration of a test class">
+                    <div class="input-group-append"><span class="input-group-text">%</span></div>
                 </div>
-            </div>
-            <div class="col">
-                <div class="button-group" data-toggle="tooltip"
+                <div class="button-group input-group" data-toggle="tooltip"
                      title="Filter tests that create their own Spring context and those that don't">
                     <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
                             style="white-space: nowrap;">
-                        Context creation<span class="caret" style="display: inline-block;"></span>
+                        Context creation<span class="caret" ></span>
                     </button>
                     <ul class="dropdown-menu">
                         <li class="dropdown-checkbox">
                             <input type="checkbox" id="include_spring_tests" checked
                                    @change="updateFunc" v-model="includeSpring"/>
                             <label for="include_spring_tests"
-                                   style="display: inline-block;">Include Spring tests</label>
+                                   >Include Spring tests</label>
                         </li>
                         <li class="dropdown-checkbox">
                             <input type="checkbox" id="include_non_spring_tests" checked
                                    @change="updateFunc" v-model="includeNonSpring"/>
                             <label for="include_non_spring_tests"
-                                   style="display: inline-block;">Include non Spring tests</label>
+                                   >Include non Spring tests</label>
                         </li>
                     </ul>
                 </div>
-            </div>
-            <div class="col">
-                <div class="button-group" style="margin-left: 10px;" data-toggle="tooltip"
+                <div class="button-group input-group" data-toggle="tooltip"
                      title="Filter tests based on their success">
                     <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
                             style="white-space: nowrap;">
-                        Test success<span class="caret" style="display: inline-block;"></span>
+                        Test success<span class="caret" ></span>
                     </button>
                     <ul class="dropdown-menu">
                         <li class="dropdown-checkbox">
                             <input type="checkbox" id="include_succeeded_tests" checked
                                    @change="updateFunc" v-model="includeSuccess"/>
                             <label for="include_succeeded_tests"
-                                   style="display: inline-block;">Include succeeded tests</label>
+                                   >Include succeeded tests</label>
                         </li>
                         <li class="dropdown-checkbox">
                             <input type="checkbox" id="include_partial_tests" checked
                                    @change="updateFunc" v-model="includePartial"/>
                             <label for="include_partial_tests"
-                                   style="display: inline-block;">Include partial succeeded tests</label>
+                                   >Include partial succeeded tests</label>
                         </li>
                         <li class="dropdown-checkbox">
                             <input type="checkbox" id="include_failed_tests" checked
                                    @change="updateFunc" v-model="includeFailure"/>
                             <label for="include_failed_tests"
-                                   style="display: inline-block;">Include failed tests</label>
+                                   >Include failed tests</label>
                         </li>
                     </ul>
                 </div>
-            </div>
-            <div class="col">
-                <div class="col">
-                    <button type="button" class="btn btn-light" v-on:click="clearClicked()" style="background-color: #FFFFFF; ">Clear</button>
-                </div>
-            </div>
+                <button type="button" class="btn btn-light input-group" v-on:click="clearClicked()" style="background-color: #FFFFFF;">Clear</button>
         </div>
     </div>
 </template>
@@ -148,42 +132,34 @@
 
 <style scoped>
     .filter {
-        display: inline;
+        margin: 10px;
     }
 
-    .right-addon {
-        position: relative;
-        width: 200px;
+    .grid-wrapper {
+        display: grid;
+        grid-gap: 10px;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr) ) ;
     }
 
-    .right-addon input {
-        padding-right: 30px;
-        width:200px;
+    .input-group-text {
+        background-color: white;
     }
 
-    .right-addon span {
-        position: absolute;
-        left: 163px;
-        padding: 7px 12px;
-        pointer-events: none;
+    .form-control {
+        border-right: 0;
     }
 
-    .test-class-container .row {
-        margin-left: 0px;
-        margin-right: 0px;
+    button.form-control.dropdown-toggle {
+        border-top-right-radius: 0.25rem;
+        border-bottom-right-radius: 0.25rem;
+        border-right: solid 1px lightgrey;
     }
 
     .dropdown-checkbox {
         white-space: nowrap;
     }
 
-    .dropdown-checkbox input {
-        display: inline-block;
-        margin-left: 10px;
+    .dropdown-menu {
+        padding: 5px;
     }
-
-    .dropdown-checkbox label {
-        margin-right: 10px;
-    }
-
 </style>


### PR DESCRIPTION
When shrinking the page, the filter component's inputs arrange in a funny way. By using CSS grids, they arrange in a nice grid way even when the screen width shrinks (see below)
![](https://i.imgur.com/kQjWgSd.png)