### PR TITLE
Place overview chart and general information next to each other

### DIFF
--- a/library/src/frontend/src/App.vue
+++ b/library/src/frontend/src/App.vue
@@ -1,11 +1,13 @@
 <template>
     <div id="app">
         <h1 style="font-size: 50px;">{{ this.report.projectName }}</h1>
-        <overview-chart :chartId="'overview'" :test-classes="report.testClasses"/>
-        <general-information
+        <div class="overview-info">
+            <overview-chart :chartId="'overview'" :test-classes="report.testClasses"/>
+            <general-information
                 :spring-contexts-created="this.report.springContextsCreated"
                 :tested-classes="this.numberOfTestedClasses"
                 :tested-methods="this.numberOfTestedMethods"/>
+        </div>
         <div>
             <h1 style="margin-top: 30px;">Time spent on individual test classes</h1>
             <test-class-filter @changed="filterFunction = $event"/>
@@ -62,5 +64,9 @@
 <style scoped>
     h1 {
         margin: 10px;
+    }
+    .overview-info {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
     }
 </style>


### PR DESCRIPTION
In the frontend, the overview sections "Overview Chart" and "General Information" can be displayed side-by-side when there is enough space.
When there isn't, they automatically place themselves underneath each other.

See picture below

![Autoplace overview elements](https://i.imgur.com/NonEpDI.png)