### PR TITLE
Create property to enable or disable JUnit Insights

### DIFF
--- a/library/src/main/kotlin/de/adesso/junitinsights/model/EventLog.kt
+++ b/library/src/main/kotlin/de/adesso/junitinsights/model/EventLog.kt
@@ -15,9 +15,19 @@ object EventLog {
     private var events: ArrayList<Event> = ArrayList()
     private var currentDate: LocalDateTime = LocalDateTime.now()
 
-    fun log(e: Event) = events.add(e)
+    fun log(e: Event) {
+        // If JUnit Insights is disabled, no events have to be logged
+        if (!InsightProperties.enabled)
+            return
+
+        events.add(e)
+    }
 
     fun writeReport() {
+        // If JUnit Insights is disabled, the report should not be created
+        if (!InsightProperties.enabled)
+            return
+
         currentDate = LocalDateTime.now() // Reset time to accommodate time between EventLog creation and writing
         val json = generateJsonFromEvents()
         val html = insertJsonInTemplate(json)

--- a/library/src/main/kotlin/de/adesso/junitinsights/tools/InsightProperties.kt
+++ b/library/src/main/kotlin/de/adesso/junitinsights/tools/InsightProperties.kt
@@ -5,13 +5,18 @@ import org.junit.jupiter.api.extension.ExtensionContext
 object InsightProperties {
     private var configurationSet = false
     var reportpath: String = ""
-    var templates: List<String>? = null
+    var enabled: Boolean = false
 
     fun setConfiguration(context: ExtensionContext) {
         if (configurationSet)
             return
+
         reportpath = context.getConfigurationParameter("de.adesso.junitinsights.reportpath")
                 .orElse("")
+
+        enabled = context.getConfigurationParameter("de.adesso.junitinsights.enabled")
+                .orElse("false")!!
+                .toBoolean()
 
         configurationSet = true
     }

--- a/tester/build.gradle
+++ b/tester/build.gradle
@@ -6,6 +6,7 @@ test {
     // Enable JUnit 5 (Gradle 4.6+).
     useJUnitPlatform()
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
+    systemProperty 'de.adesso.junitinsights.enabled', 'true'
     systemProperty 'de.adesso.junitinsights.reportpath', 'reports/'
 }
 


### PR DESCRIPTION
Up to this point, disabling the extension was done by disabling the JUnit Jupiter extension autodetection. This had the drawback, that all the other callbacks were still enabled and the report was created anyways which lead to some unpredictable behavior.

Also this way, we can write unit tests for our library more easily.