### PR TITLE
Move margins to containing element

### DIFF
--- a/library/src/frontend/src/App.vue
+++ b/library/src/frontend/src/App.vue
@@ -57,6 +57,12 @@
                     .reduce((a, b) => a + b, 0);
             }
         },
+        mounted: function() {
+            Plotly.Plots.resize("overview");
+            this.filteredAndSorted.forEach(element => {
+                Plotly.Plots.resize(element.name);
+            });
+        },
         components: {
             TestClassSorter,
             TestClassFilter,

--- a/library/src/frontend/src/App.vue
+++ b/library/src/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="app">
         <h1 style="font-size: 50px;">{{ this.report.projectName }}</h1>
-        <button type="button" class="btn btn-light help-button" v-on:click="showHelp = true"><h2>?</h2></button>
+        <button type="button" class="btn help-button" v-on:click="showHelp = true"><h2>?</h2></button>
         <HelpDialog v-if="showHelp" v-on:close="showHelp = false"></HelpDialog>
         <div class="overview-info">
             <overview-chart :chartId="'overview'" :test-classes="report.testClasses"/>
@@ -93,7 +93,12 @@
         position: absolute;
         right: 10px;
         top: 10px;
-        border-radius: 0;
+        background-color: #FFFFFF;
+        border: solid 1px lightgrey;
+    }
+
+    .help-button:hover, .help-button:focus, .help-button:active {
+        background-color: #EEEEEE;
     }
 
     #class-charts > * {

--- a/library/src/frontend/src/App.vue
+++ b/library/src/frontend/src/App.vue
@@ -15,10 +15,12 @@
             <test-class-filter @changed="filterFunction = $event"/>
             <test-class-sorter @changed="sortFunction = $event"/>
         </div>
-        <class-chart v-for="testClass in filteredAndSorted"
-                     :key="testClass.name"
-                     :test-class="testClass"
-                     :chartId="testClass.name"/>
+        <div id="class-charts">
+            <class-chart v-for="testClass in filteredAndSorted"
+                        :key="testClass.name"
+                        :test-class="testClass"
+                        :chartId="testClass.name"/>
+        </div>
     </div>
 </template>
 
@@ -67,23 +69,35 @@
 </script>
 
 <style scoped>
-    h1 {
-        margin: 10px;
+    #app {
+        padding: 10px;
     }
 
-    .overview-info {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(500px, 1fr) 350px)
+    @media only screen and (min-width: 1200px){
+        .overview-info {
+            display: grid;
+            grid-gap: 10px;
+            grid-template-columns: 1fr 350px;
+        }
+    }
+
+    @media only screen and (max-width: 1200px) {
+        .overview-info > * {
+            margin-top: 10px;
+        }
     }
 
     .help-button {
-        float: right;
         width: 50px;
         height: 50px;
-        margin-top: 20px;
-        margin-right: 20px;
         position: absolute;
-        right: 0;
-        top: 0;
+        right: 10px;
+        top: 10px;
+        border-radius: 0;
     }
+
+    #class-charts > * {
+        margin-top: 10px;
+    }
+
 </style>

--- a/library/src/frontend/src/components/ChartBase.vue
+++ b/library/src/frontend/src/components/ChartBase.vue
@@ -52,24 +52,17 @@
         },
         mounted: function () {
             if (this.shouldDraw()) {
-                Plotly.newPlot(this.chartId, this.chartEntries, this.layout);
-                window.addEventListener("resize", this.handleResize);
-                this.handleResize();
+                Plotly.newPlot(this.chartId, this.chartEntries, this.layout, {responsive: true});
             }
         },
         beforeDestroy: function () {
             if (this.shouldDraw()) {
-                window.removeEventListener("resize", this.handleResize);
-                // Plotly.purge(this.chartId);
             }
         },
         methods: {
             // Override in inheriting component to define specific logic
             shouldDraw: function () {
                 return true;
-            },
-            handleResize() {
-                Plotly.Plots.resize(this.chartId);
             },
             getChartEntry(data, text, color) {
                 return {

--- a/library/src/frontend/src/components/ClassChart.vue
+++ b/library/src/frontend/src/components/ClassChart.vue
@@ -59,15 +59,11 @@
         border: solid 1px lightgray;
         border-radius: 2px;
         padding: 10px;
-        margin: 10px;
     }
 
     .expandButton {
         display: inline;
-        margin-top: -13px;
         font-size: 20px;
         background-color: #FFFFFF;
-        width: 38px;
-        height: 38px;
     }
 </style>

--- a/library/src/frontend/src/components/GeneralInformation.vue
+++ b/library/src/frontend/src/components/GeneralInformation.vue
@@ -33,7 +33,6 @@
     .generalInformation {
         border: solid 1px lightgray;
         border-radius: 2px;
-        margin: 10px;
         padding: 10px;
     }
 </style>

--- a/library/src/frontend/src/components/HelpDialog.vue
+++ b/library/src/frontend/src/components/HelpDialog.vue
@@ -37,7 +37,7 @@
 
                 <div class="modal-footer">
                     <slot name="footer">
-                        <button class="modal-default-button btn btn-light" @click="$emit('close')">
+                        <button class="modal-default-button btn close-button" @click="$emit('close')">
                             OK
                         </button>
                     </slot>
@@ -71,5 +71,14 @@
         background-color: #fff;
         border-radius: 2px;
         box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+    }
+
+    .close-button {
+        background-color: #FFFFFF;
+        border: solid 1px lightgrey;
+    }
+
+    .close-button:hover, .close-button:focus, .close-button:active {
+        background-color: #EEEEEE;
     }
 </style>

--- a/library/src/frontend/src/components/OverviewChart.vue
+++ b/library/src/frontend/src/components/OverviewChart.vue
@@ -50,6 +50,5 @@
         border: solid 1px lightgray;
         border-radius: 2px;
         padding: 10px;
-        margin: 10px;
     }
 </style>

--- a/library/src/frontend/src/components/TestClassFilter.vue
+++ b/library/src/frontend/src/components/TestClassFilter.vue
@@ -131,10 +131,6 @@
 </script>
 
 <style scoped>
-    .filter {
-        margin: 10px;
-    }
-
     .grid-wrapper {
         display: grid;
         grid-gap: 10px;

--- a/library/src/frontend/src/components/TestClassFilter.vue
+++ b/library/src/frontend/src/components/TestClassFilter.vue
@@ -27,7 +27,7 @@
             </div>
             <div class="button-group input-group" data-toggle="tooltip"
                  title="Filter tests that create their own Spring context and those that don't">
-                <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
+                <button type="button" class="btn form-control dropdown-toggle" data-toggle="dropdown"
                         style="white-space: nowrap;">
                     Context creation<span class="caret" ></span>
                 </button>
@@ -48,7 +48,7 @@
             </div>
             <div class="button-group input-group" data-toggle="tooltip"
                  title="Filter tests based on their success">
-                <button type="button" class="form-control dropdown-toggle" data-toggle="dropdown"
+                <button type="button" class="btn form-control dropdown-toggle" data-toggle="dropdown"
                         style="white-space: nowrap;">
                     Test success<span class="caret" ></span>
                 </button>
@@ -73,7 +73,7 @@
                     </li>
                 </ul>
             </div>
-            <button type="button" class="btn btn-light" v-on:click="clearClicked()" style="background-color: #FFFFFF;">Clear</button>
+            <button type="button" class="btn clear-button" v-on:click="clearClicked()">Clear</button>
         </div>
     </div>
 </template>
@@ -145,10 +145,12 @@
         border-right: 0;
     }
 
-    button.form-control.dropdown-toggle {
-        border-top-right-radius: 0.25rem;
-        border-bottom-right-radius: 0.25rem;
-        border-right: solid 1px lightgrey;
+    .dropdown-toggle {
+        border: solid 1px lightgrey;
+    }
+
+    .dropdown-toggle:hover, .dropdown-toggle:focus, .dropdown-toggle:active {
+        background-color: #EEEEEE;
     }
 
     .dropdown-checkbox {
@@ -157,5 +159,14 @@
 
     .dropdown-menu {
         padding: 5px;
+    }
+
+    .clear-button {
+        background-color: #FFFFFF;
+        border: solid 1px lightgrey;
+    }
+
+    .clear-button:hover, .clear-button:focus, .clear-button:active {
+        background-color: #EEEEEE;
     }
 </style>

--- a/library/src/frontend/src/components/TestClassSorter.vue
+++ b/library/src/frontend/src/components/TestClassSorter.vue
@@ -12,7 +12,7 @@
                 </select>
             </label>
             <div class="col" style="display: inline;">
-                <button class="btn btn-light" style="background-color: #FFFFFF;" type="button" @click="ascending = !ascending; updateFunc();">
+                <button class="btn up-down-button" type="button" @click="ascending = !ascending; updateFunc();">
                     {{ascending ? "&darr;" : "&uarr;"}}
                 </button>
             </div>
@@ -81,5 +81,14 @@
 <style scoped>
     .sorter {
         display: inline;
+    }
+
+    .up-down-button {
+        background-color: #FFFFFF;
+        border: solid 1px lightgrey;
+    }
+
+    .up-down-button:hover, .up-down-button:focus, .up-down-button:active {
+        background-color: #EEEEEE;
     }
 </style>


### PR DESCRIPTION
The way margins in the app were handled was inconsistent. With this change, the margin between elements is determined by the parent element rather than the children itself.
Also, using [CSS media queries](https://www.w3schools.com/cssref/css3_pr_mediaquery.asp), the overview chart and general information panel are places underneath each other in a not-so-hacky way than before.