### PR TITLE
Separate from the Spring framework as much as possible

### DIFF
--- a/library/src/main/kotlin/de/adesso/junitinsights/model/EventLog.kt
+++ b/library/src/main/kotlin/de/adesso/junitinsights/model/EventLog.kt
@@ -41,7 +41,7 @@ object EventLog {
     }
 
     private fun insertJsonInTemplate(json: String): String {
-        val template = InputStreamReader(ClassPathResource("index.html").inputStream).readText()
+        val template = InputStreamReader(this.javaClass.getResourceAsStream("/index.html")).readText()
         return template.replace("var OVERRIDE_REPORT = {}", "var OVERRIDE_REPORT = $json")
     }
 


### PR DESCRIPTION
We have read the index template file from the classpath with Spring tools before. However we should separate as much as possible from the Spring framework to seamlessly integrate in non-spring projects.

Another issue with this is the fact that we always create a Spring context, regardless of if we need it or not. (See: https://github.com/adessoAG/junit-insights/blob/master/library/src/main/kotlin/de/adesso/junitinsights/spring/InsightConfiguration.kt)