### PR TITLE
Improve build files and fix JAR generation and travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,3 @@ deploy:
   key: $BINTRAY_API_KEY
   dry-run: false
   skip_cleanup: true
-  on:
-    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ jdk:
 before_install:
   - cd library
   - chmod +x gradlew
-install:
   - cd src/frontend
   - npm install
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ deploy:
   key: $BINTRAY_API_KEY
   dry-run: false
   skip_cleanup: true
+  on:
+    all_branches: true

--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,11 @@ subprojects {
 
     compileKotlin {
         kotlinOptions {
-            freeCompilerArgs = ['-Xjsr305=strict']
             jvmTarget = '1.8'
         }
     }
     compileTestKotlin {
         kotlinOptions {
-            freeCompilerArgs = ['-Xjsr305=strict']
             jvmTarget = '1.8'
         }
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,19 +28,16 @@ model {
     }
 }
 
-task fatJar(type: Jar) {
-    baseName = 'junit-insights'
-    from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
-    with jar
-    exclude("node_modules", "src", "package.json", "package-lock.json", "webpack.config.js", "main.js")
-}
-
 bootJar {
     enabled = false
 }
 
 jar {
     enabled = true
+    baseName = 'junit-insights'
+    from {
+        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
+    }
     exclude("node_modules", "src", "package.json", "package-lock.json", "webpack.config.js", "main.js")
 }
 
@@ -77,8 +74,8 @@ task npmRunBuild(type: Exec) {
 }
 
 build.dependsOn npmRunBuild
-build.dependsOn fatJar
-assemble.dependsOn fatJar
+build.dependsOn jar
+assemble.dependsOn jar
 
 dependencies {
     compile('org.jetbrains.kotlin:kotlin-reflect')

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,8 +1,36 @@
+// Import of plugins
+
 apply plugin: 'maven-publish'
+
+// Global variable declarations
 
 group = 'de.adesso'
 version = '0.0.1'
 sourceCompatibility = 1.8
+
+// Build tasks
+
+jar {
+    enabled = true
+    baseName = 'junit-insights'
+    from {
+        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    exclude("node_modules", "src", "package.json", "package-lock.json", "webpack.config.js", "main.js")
+}
+
+bootJar {
+    enabled = false
+}
+
+// Test tasks
+
+test {
+    useJUnitPlatform()
+    systemProperty 'de.adesso.junitinsights.enabled', 'false'
+}
+
+// Publishing tasks
 
 publishing {
     publications {
@@ -28,23 +56,7 @@ model {
     }
 }
 
-bootJar {
-    enabled = false
-}
-
-jar {
-    enabled = true
-    baseName = 'junit-insights'
-    from {
-        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    exclude("node_modules", "src", "package.json", "package-lock.json", "webpack.config.js", "main.js")
-}
-
-test {
-    systemProperty 'de.adesso.junitinsights.enabled', 'false'
-    useJUnitPlatform()
-}
+// npm specific tasks
 
 task npmInstall(type: Exec) {
     inputs.files(
@@ -73,8 +85,7 @@ task npmRunBuild(type: Exec) {
     }
 }
 
-build.dependsOn jar
-assemble.dependsOn jar
+// Dependency declarations
 
 dependencies {
     compile('org.jetbrains.kotlin:kotlin-reflect')
@@ -87,10 +98,4 @@ dependencies {
     testCompile('org.junit.jupiter:junit-jupiter-engine:5.1.0')
     testCompile('org.junit.platform:junit-platform-launcher:1.1.0')
     testCompile('org.springframework.boot:spring-boot-starter')
-
-    // You can easily generate your own configuration metadata file from items annotated with
-    // @ConfigurationProperties by using the spring-boot-configuration-processor jar. The jar
-    // includes a Java annotation processor which is invoked as your project is compiled.
-    // To use the processor, include a dependency on spring-boot-configuration-processor.
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'maven-publish'
 
+group = 'de.adesso'
+version = '0.0.1'
+sourceCompatibility = 1.8
+
 publishing {
     publications {
         maven(MavenPublication) {
@@ -20,13 +24,9 @@ publishing {
 
 model {
     tasks.generatePomFileForMavenPublication {
-        destination = file('$buildDir/libs/junit-insights-0.0.1.pom')
+        destination = file("${buildDir}/libs/junit-insights-${version}.pom")
     }
 }
-
-group = 'de.adesso'
-version = '0.0.1'
-sourceCompatibility = 1.8
 
 task fatJar(type: Jar) {
     baseName = 'junit-insights'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -73,7 +73,6 @@ task npmRunBuild(type: Exec) {
     }
 }
 
-build.dependsOn npmRunBuild
 build.dependsOn jar
 assemble.dependsOn jar
 

--- a/tester/build.gradle
+++ b/tester/build.gradle
@@ -1,6 +1,10 @@
+// Global variable declarations
+
 group = 'de.adesso.example'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
+
+// Test tasks
 
 test {
     // Enable JUnit 5 (Gradle 4.6+).
@@ -9,6 +13,8 @@ test {
     systemProperty 'de.adesso.junitinsights.enabled', 'true'
     systemProperty 'de.adesso.junitinsights.reportpath', 'reports/'
 }
+
+// Dependency declarations
 
 dependencies {
     testCompile('org.junit.jupiter:junit-jupiter-api:5.1.0')


### PR DESCRIPTION
This PR addresses multiple issues with the build and deployment process:

- fix broken deployment of our JAR file
- fix malfunctioning generation of the pom file for the bintray deployment
- remove unnecessary things from the build files
- restructure build files for easier understanding of the different tasks
- fix broken JAR file which was missing the HTML file for the report creation (Fix #97)