### PR TITLE
WIP: Improve logging

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -190,7 +190,13 @@ dependencies {
 
     compileOnly('org.junit.jupiter:junit-jupiter-api:5.1.0')
     compileOnly('org.junit.platform:junit-platform-launcher:1.1.0')
-    compileOnly('org.springframework.boot:spring-boot-starter')
+
+    // Remove Logging implementation from spring-boot-starter and only import the slf4j API.
+    // This lets the client application choose a logging solution.
+    compileOnly('org.springframework.boot:spring-boot-starter') {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
 
     testCompile('org.junit.jupiter:junit-jupiter-engine:5.1.0')
     testCompile('org.junit.platform:junit-platform-launcher:1.1.0')

--- a/library/src/main/kotlin/de/adesso/junitinsights/junit/JUnitCallbacks.kt
+++ b/library/src/main/kotlin/de/adesso/junitinsights/junit/JUnitCallbacks.kt
@@ -8,8 +8,9 @@ import org.junit.jupiter.api.extension.*
 import org.junit.platform.commons.support.AnnotationSupport.isAnnotated
 import org.junit.platform.launcher.TestExecutionListener
 import org.junit.platform.launcher.TestPlan
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.util.*
-
 
 /**
  * Extension that measures the execution time of each test class and method.
@@ -23,6 +24,8 @@ class JUnitCallbacks :
 
     private val reportWriter: IReportWriter = ReportWriter
     private val reportCreator: IReportCreator = ReportCreator
+
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     /**
      * These methods get called at certain events in the JUnit test plan execution.
@@ -75,11 +78,14 @@ class JUnitCallbacks :
      * Gets called after the complete test plan has been executed, so the report can be generated.
      */
     override fun testPlanExecutionFinished(testPlan: TestPlan) {
+        logger.debug("Test plan execution finished, commencing JUnit Insights report creation...")
         val report = reportCreator.createReport(EventLog.events)
+        logger.debug("Writing report to file...")
         reportWriter.writeReport(report)
     }
 
     private fun saveTimestamp(event: String, context: ExtensionContext, testFailing: Boolean = false) {
+        logger.debug("Saving event to log: $event")
         if (shouldNotBeBenched(context))
             return
 

--- a/library/src/main/kotlin/de/adesso/junitinsights/tools/ReportWriter.kt
+++ b/library/src/main/kotlin/de/adesso/junitinsights/tools/ReportWriter.kt
@@ -22,7 +22,7 @@ object ReportWriter : IReportWriter {
         val json = generateJsonFromReport(report)
         val html = insertJsonInTemplate(json)
         val reportFile = writeHtmlToFile(html, InsightProperties.reportpath, getReportFileName(report))
-        LoggerFactory.getLogger(this::class.java).debug("Report created at ${reportFile.absolutePath}")
+        LoggerFactory.getLogger(this::class.java).info("Report created at ${reportFile.absolutePath}")
     }
 
     private fun generateJsonFromReport(report: Report): String = Gson().toJson(report)

--- a/tester/src/main/resources/logback.xml
+++ b/tester/src/main/resources/logback.xml
@@ -8,6 +8,8 @@
         </encoder>
     </appender>
 
+    <logger name="de.adesso.junitinsights" level="debug"/>
+
     <root level="debug">
         <appender-ref ref="STDOUT" />
     </root>

--- a/tester/src/main/resources/logback.xml
+++ b/tester/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+         <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Fix #112 

Added some additional logging statements to make it easier to see whats going on during testing.

I ran into some issues though: When running the tester's test suite, there is only one log output that says `Saving event to log: ...`
Here is that I observed:
- As I mentioned above, there is only a single debug output at the very beginning of the test run
- When changing the line from `logger.debug(...)` to `logger.info(...)`, the desired output is visible, but we can't use that log level as it is way to verbose for big projects
- Other debug-level outputs are visible in the log
- The `logback.xml` is found on the classpath during execution, as changing the log level from `debug` to `info` in that file hides all debug-level output

UPDATE:
Managed to manually configure the log level for the tester. Before we merge these changes however, I'd like to test it out with a few sample projects to see if the logging works as expected with different logging frameworks.
There should also be a reference in the readme.