### PR TITLE
Remove embedded copy of Kotlin

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -185,7 +185,7 @@ task npmRunBuild(type: Exec) {
 // Dependency declarations
 
 dependencies {
-    compile('org.jetbrains.kotlin:kotlin-reflect')
+    implementation('org.jetbrains.kotlin:kotlin-reflect')
     compile('com.google.code.gson:gson:2.7')
 
     compileOnly('org.junit.jupiter:junit-jupiter-api:5.1.0')

--- a/tester/build.gradle
+++ b/tester/build.gradle
@@ -17,6 +17,7 @@ test {
 // Dependency declarations
 
 dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
     testCompile('org.junit.jupiter:junit-jupiter-api:5.1.0')
     testCompile('org.springframework.boot:spring-boot-starter-test')
     compile('org.springframework.boot:spring-boot-starter-web')


### PR DESCRIPTION
The Kotlin version used to build the project is included in the JAR and
causes downstream projects to fail to compile. When removing the dependency
the tester module needs to provide Kotlin, so a dependency was added.

Closes: #125